### PR TITLE
Added an estimate time completion to the display of the train command…

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -27,7 +27,7 @@ training:
       the probability of "tails"; and since no other outcomes are possible, the
       probability of either "heads" or "tails" is 1/2
       (which could also be written as 0.5 or 50%).
-
+    reward: |
       {bold Reward:}
         {cyan.green +1 luck}
   luck-02:
@@ -44,7 +44,7 @@ training:
       system can result in large differences in a later state, meaning there is
       sensitive dependence on initial conditions. A metaphor for this behavior is
       that a butterfly flapping its wings in China can cause a hurricane in Texas.
-
+    reward: |
       {bold Reward:}
         {cyan.green +1 luck}
   scan-01:
@@ -60,7 +60,7 @@ training:
       name and version) those hosts are offering, what operating systems
       (and OS versions) they are running, what type of packet filters/firewalls are
       in use, and dozens of other characteristics.
-
+    reward: |
       {bold Reward:}
         {cyan.green nscan}
   scan-02:
@@ -71,7 +71,7 @@ training:
       IoT devices, or any of the many things in the internet of things, are
       nonstandard computing devices that connect wirelessly to a network and
       have the ability to transmit data.
-
+    reward: |
       {bold Reward:}
         {cyan.green nscan for IoT devices}
   scan-03:
@@ -82,7 +82,7 @@ training:
       IoT devices, or any of the many things in the internet of things, are
       nonstandard computing devices that connect wirelessly to a network and
       have the ability to transmit data.
-
+    reward: |
       {bold Reward:}
         {cyan.green nscan for IoT devices}
   crypto-01:
@@ -96,7 +96,7 @@ training:
       transactions, control the creation of additional units, and verify the
       transfer of assets. Cryptocurrencies use decentralized control as opposed
       to centralized digital currency and central banking systems.
-
+    reward: |
       {bold Reward:}
         {cyan.green coind package}
         {cyan.green wallet package}

--- a/src/commands/train.command.js
+++ b/src/commands/train.command.js
@@ -20,10 +20,19 @@ const allTraining = config.get('training')
 const getTime = state =>
   getHumanizedDuration(Date.parse(state.training_currently.end_at), Date.now())
 
-const humanizeLesson = ([name, value]) =>
-  chalk`{bold.cyan ${name}: ${value.headline}}
-  
-  ${chalkTemplate(value.body.replace(/\n/g, '\n  '))}`
+const humanizeLesson = ([name, value]) => {
+  const futureDate = new Date()
+  futureDate.setSeconds(futureDate.getSeconds() + value.time)
+
+  return chalk`{bold.cyan ${name}: ${value.headline}}
+
+  ${chalkTemplate(value.body.replace(/\n/g, '\n  '))}
+
+  {bold Estimated time completion:}
+    ${getHumanizedDuration(futureDate, Date.now())}${'\n  '}
+
+  ${chalkTemplate(value.reward.replace(/\n/g, '\n  '))}`
+}
 
 const meetsRequirement = ({
   session,


### PR DESCRIPTION
… options; Closes #45


I removed the rewards from the body of each training option and added them in their own section so they can now be arranged in every way we want for the display.

I thought it was better because with that method i didn't have to add the estimate time completion to the body aswell since the info is already written in the `time` section that wouldn't have been SOLID !

Let me know if you want me to change anything :)